### PR TITLE
Batching domain name resolutions

### DIFF
--- a/jobs/domain-name-resolving/main.py
+++ b/jobs/domain-name-resolving/main.py
@@ -1,17 +1,29 @@
 import os
 import socket
+import json
 
-from stalker_job_sdk import DomainFinding, JobStatus, log_finding, log_status
+from stalker_job_sdk import DomainFinding, JobStatus, log_finding, log_status, log_error
 
-hostname = os.environ.get("domainName")
-data = socket.gethostbyname_ex(hostname)
-ipx = data[2]
 
-for ip in ipx:
-    log_finding(
-        DomainFinding(
-            "HostnameIpFinding", hostname, ip, "New ip", [], "HostnameIpFinding"
-        )
-    )
+def main():
+    hostnames = json.loads(os.environ.get("domainNames"))
 
-log_status(JobStatus.SUCCESS)
+    for hostname in hostnames:
+        data = socket.gethostbyname_ex(hostname)
+        ipx = data[2]
+
+        for ip in ipx:
+            log_finding(
+                DomainFinding(
+                    "HostnameIpFinding", hostname, ip, "New ip", [], "HostnameIpFinding"
+                )
+            )
+
+try:
+    main()
+    log_status(JobStatus.SUCCESS)
+except Exception as err:
+    log_error("An unexpected error occured")
+    log_error(err)
+    log_status(JobStatus.FAILED)
+    exit()

--- a/jobs/domain-name-resolving/template.yaml
+++ b/jobs/domain-name-resolving/template.yaml
@@ -2,8 +2,8 @@ name: DomainNameResolvingJob
 type: code
 language: python
 parameters:
-  - name: domainName
-    type: string
+  - name: domainNames
+    type: string[]
 jobPodConfigName: XS
 category: "built-in/python"
 image: "ghcr.io/red-kite-solutions/stalker-python-job-base:2"

--- a/subscriptions/domain-name-resolution.yml
+++ b/subscriptions/domain-name-resolution.yml
@@ -6,5 +6,6 @@ cooldown: 82800
 job:
   name: DomainNameResolvingJob
   parameters:
-    - name: domainName
-      value: ${domainName}
+    - name: domainNames
+      value: 
+        - ${domainName}

--- a/subscriptions/refresh_all_domains.yaml
+++ b/subscriptions/refresh_all_domains.yaml
@@ -1,9 +1,12 @@
 name: Refreshing all domain names
 input: ALL_DOMAINS
+batch:
+  enabled: true
+  size: 100
 triggerType: cron
 cronExpression: "0 0 */7 * *"
 job:
   name: DomainNameResolvingJob
   parameters:
-    - name: domainName
-      value: ${domainName}
+    - name: domainNames
+      value: ${domainBatch}


### PR DESCRIPTION
This PR depends on the pull request here: 

https://github.com/red-kite-solutions/stalker/pull/330

It modifies the domain name resolving job to support an array as input. It also modifies its cron subscription to use the batching mechanic, feeding 100 domains at the time, instead of 1.

Giving a database with 10 000 domain names for a project, it would make, instead of 10 000 different jobs, 100, which is a much more manageable amount.

